### PR TITLE
warning: calling URI.open via Kernel#open is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /data/fonts/*.ttf
+*.gem

--- a/asciidoctor-pdf-cjk-kai_gen_gothic.gemspec
+++ b/asciidoctor-pdf-cjk-kai_gen_gothic.gemspec
@@ -6,12 +6,21 @@ require 'asciidoctor/pdf/cjk/kai_gen_gothic/version'
 Gem::Specification.new do |spec|
   spec.name          = "asciidoctor-pdf-cjk-kai_gen_gothic"
   spec.version       = Asciidoctor::Pdf::CJK::KaiGenGothic::VERSION
-  spec.authors       = ["Rei"]
-  spec.email         = ["chloerei@gmail.com"]
+  spec.authors       = ["Yuhang Guo"]
+  spec.email         = ["22561797+Sherry520@users.noreply.github.com"]
 
-  spec.summary       = %q{}
-  spec.description   = %q{}
-  spec.homepage      = ""
+  spec.summary       = "This is an unofficial extended support of asciidoctor-pdf-cjk-kai_gen_gothic"
+  spec.description   = <<-EOF
+Waining:\n
+This is an unofficial extended support of asciidoctor-pdf-cjk-kai_gen_gothic.\n
+This official gem is no longer maintained.\n
+Detail information can find on: https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic \n
+I won't make any changes to the font, just make sure it keeps downloading.
+
+  EOF
+
+  spec.license       = 'MIT'
+  spec.homepage      = "https://github.com/Sherry520/asciidoctor-pdf-cjk-kai_gen_gothic-ex"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
@@ -29,6 +38,7 @@ Run this command to download required fonts:
 
   EOF
 
+  spec.required_ruby_version = '>= 2.7.0'
   spec.add_dependency "asciidoctor-pdf-cjk", "~> 0.1.2"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/asciidoctor-pdf-cjk-kai_gen_gothic.gemspec
+++ b/asciidoctor-pdf-cjk-kai_gen_gothic.gemspec
@@ -20,7 +20,7 @@ I won't make any changes to the font, just make sure it keeps downloading.
   EOF
 
   spec.license       = 'MIT'
-  spec.homepage      = "https://github.com/Sherry520/asciidoctor-pdf-cjk-kai_gen_gothic-ex"
+  spec.homepage      = "https://github.com/Sherry520/asciidoctor-pdf-cjk-kai_gen_gothic"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"

--- a/exe/asciidoctor-pdf-cjk-kai_gen_gothic-install
+++ b/exe/asciidoctor-pdf-cjk-kai_gen_gothic-install
@@ -31,7 +31,7 @@ Dir.chdir(FontsDir) do
   Fonts.each_with_index do |name, index|
     puts "[#{index + 1}/#{Fonts.count}] Downloading #{name}"
     File.open(name, 'wb') do |file|
-      file.write URL.open("https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts/#{name}").read
+      file.write URI.open("https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts/#{name}").read
     end
   end
 end

--- a/exe/asciidoctor-pdf-cjk-kai_gen_gothic-install
+++ b/exe/asciidoctor-pdf-cjk-kai_gen_gothic-install
@@ -31,7 +31,7 @@ Dir.chdir(FontsDir) do
   Fonts.each_with_index do |name, index|
     puts "[#{index + 1}/#{Fonts.count}] Downloading #{name}"
     File.open(name, 'wb') do |file|
-      file.write open("https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts/#{name}").read
+      file.write URL.open("https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts/#{name}").read
     end
   end
 end

--- a/lib/asciidoctor/pdf/cjk/kai_gen_gothic/version.rb
+++ b/lib/asciidoctor/pdf/cjk/kai_gen_gothic/version.rb
@@ -2,7 +2,7 @@ module Asciidoctor
   module Pdf
     module CJK
       module KaiGenGothic
-        VERSION = "0.1.1"
+        VERSION = "0.1.2"
       end
     end
   end


### PR DESCRIPTION
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open